### PR TITLE
Un-obsoleted, optimized, fixed items not dropping

### DIFF
--- a/SCP-008/Commands.cs
+++ b/SCP-008/Commands.cs
@@ -23,7 +23,7 @@ namespace SCP008
 						return;
 					}
 
-					ReferenceHub player = Plugin.GetPlayer(args[1]);
+					ReferenceHub player = Player.GetPlayer(args[1]);
 					if (player == null)
 					{
 						ev.Sender.RAMessage($"Player not found: {args[1]}", false);
@@ -49,7 +49,7 @@ namespace SCP008
 						return;
 					}
 
-					ReferenceHub player = Plugin.GetPlayer(args[1]);
+					ReferenceHub player = Player.GetPlayer(args[1]);
 					if (player == null)
 					{
 						ev.Sender.RAMessage($"Player not found: {args[1]}", false);

--- a/SCP-008/EventHandlers.cs
+++ b/SCP-008/EventHandlers.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using EXILED;
+using EXILED.Extensions;
 using MEC;
 using UnityEngine;
 
@@ -38,17 +39,17 @@ namespace SCP008
 
 			if (ev.Attacker == null || string.IsNullOrEmpty(ev.Attacker.characterClassManager.UserId))
 			{
-				Plugin.Debug("Attacker could not be found.");
+				Log.Debug("Attacker could not be found.");
 				return;
 			}
 
-			if (ev.Attacker.characterClassManager.CurClass == RoleType.Scp0492 && Plugin.GetTeam(ev.Player.characterClassManager.CurClass) != Team.SCP)
+			if (ev.Attacker.characterClassManager.CurClass == RoleType.Scp0492 && ev.Player.GetTeam() != Team.SCP)
 			{
 				int r = plugin.Gen.Next(100);
-				Plugin.Debug($"Roll: {r}. Target: {plugin.InfectionChance}");
+				Log.Debug($"Roll: {r}. Target: {plugin.InfectionChance}");
 				if (r <= plugin.InfectionChance)
 				{
-					Plugin.Debug($"Infecting {ev.Player.nicknameSync.MyNick} ({ev.Player.characterClassManager.CurClass}");
+					Log.Debug($"Infecting {ev.Player.nicknameSync.MyNick} ({ev.Player.characterClassManager.CurClass}");
 					plugin.Functions.InfectPlayer(ev.Player);
 				}
 			}

--- a/SCP-008/EventHandlers.cs
+++ b/SCP-008/EventHandlers.cs
@@ -33,7 +33,9 @@ namespace SCP008
 					{
 						Vector3 pos = ev.Player.gameObject.transform.position;
 						Timing.RunCoroutine(plugin.Functions.TurnIntoZombie(ev.Player, new Vector3(pos.x, pos.y, pos.z)));
+						ev.Player.inventory.ServerDropAll();
 						ev.Info = new PlayerStats.HitInfo(0f, ev.Info.Attacker, ev.Info.GetDamageType(), ev.Info.PlyId);
+						return;
 					}
 				}
 
@@ -53,11 +55,6 @@ namespace SCP008
 					plugin.Functions.InfectPlayer(ev.Player);
 				}
 			}
-		}
-
-		public void OnPlayerDeath(ref PlayerDeathEvent ev)
-		{
-			
 		}
 
 		public void OnUseMedicalItem(MedicalItemEvent ev)

--- a/SCP-008/Methods.cs
+++ b/SCP-008/Methods.cs
@@ -49,6 +49,7 @@ namespace SCP008
 			GameObject gameObject = player.gameObject;
 			Vector3 pos = gameObject.transform.position;
 
+			player.inventory.ServerDropAll();
 			Timing.RunCoroutine(TurnIntoZombie(player, pos));
 
 			yield return Timing.WaitForSeconds(0.6f);
@@ -61,16 +62,13 @@ namespace SCP008
 		
 		public IEnumerator<float> TurnIntoZombie(ReferenceHub player, Vector3 position)
 		{
-			CurePlayer(player);
 			if (player.characterClassManager.CurClass == RoleType.Scp0492)
 			{
 				yield break;
 			}
 			yield return Timing.WaitForSeconds(0.3f);
-			CurePlayer(player);
 			player.characterClassManager.SetClassIDAdv(RoleType.Scp0492, false);
 			yield return Timing.WaitForSeconds(2.5f);
-			CurePlayer(player);
 			player.playerStats.health = player.playerStats.maxHP;
 			player.plyMovementSync.OverridePosition(position, player.gameObject.transform.rotation.y);
 			CurePlayer(player);

--- a/SCP-008/Methods.cs
+++ b/SCP-008/Methods.cs
@@ -15,34 +15,34 @@ namespace SCP008
 		{
 			if (plugin.InfectedPlayers.Contains(player))
 			{
-				Plugin.Debug($"{player.nicknameSync.MyNick} already infected.");
+				Log.Debug($"{player.nicknameSync.MyNick} already infected.");
 				return;
 			}
 
 			if (player.characterClassManager.IsAnyScp())
 			{
-				Plugin.Debug($"{player.nicknameSync.MyNick} is an SCP.");
+				Log.Debug($"{player.nicknameSync.MyNick} is an SCP.");
 				return;
 			}
 			plugin.InfectedPlayers.Add(player);
 
-			Plugin.Debug($"{player.nicknameSync.MyNick} infected.");
+			Log.Debug($"{player.nicknameSync.MyNick} infected.");
 			plugin.Coroutines.Add(Timing.RunCoroutine(DoInfectionTimer(player), $"{player.characterClassManager.UserId}"));
 		}
 
 		private IEnumerator<float> DoInfectionTimer(ReferenceHub player)
 		{
-			Plugin.Debug($"Infection timer for {player.nicknameSync.MyNick} started.");
+			Log.Debug($"Infection timer for {player.nicknameSync.MyNick} started.");
 			for (int i = 0; i < plugin.InfectionLength; i++)
 			{
 				if (!plugin.InfectedPlayers.Contains(player))
 				{
-					Plugin.Debug($"{player.nicknameSync.MyNick} is no longer on infected list, halting timer.");
+					Log.Debug($"{player.nicknameSync.MyNick} is no longer on infected list, halting timer.");
 					yield break;
 				}
 
 				player.gameObject.GetComponent<Broadcast>().RpcClearElements();
-				player.Broadcast(1, $"You are infected with SCP-008. The infection will take over in {plugin.InfectionLength - i} seconds!");
+				player.Broadcast(1, $"You are infected with SCP-008. The infection will take over in {plugin.InfectionLength - i} seconds!", false);
 				yield return Timing.WaitForSeconds(1f);
 			}
 
@@ -53,7 +53,7 @@ namespace SCP008
 
 			yield return Timing.WaitForSeconds(0.6f);
 			
-			foreach (ReferenceHub hub in EXILED.Plugin.GetHubs())
+			foreach (ReferenceHub hub in Player.GetHubs())
 				if (Vector3.Distance(hub.gameObject.transform.position, player.gameObject.transform.position) < 10f && hub.characterClassManager.IsHuman() && hub != player)
 					InfectPlayer(hub);
 			CurePlayer(player);

--- a/SCP-008/Plugin.cs
+++ b/SCP-008/Plugin.cs
@@ -16,7 +16,7 @@ namespace SCP008
 		public float InfectionChance;
 		public bool TurnInfectedOnDeath;
 		
-		public List<ReferenceHub> InfectedPlayers = new List<ReferenceHub>();
+		public HashSet<ReferenceHub> InfectedPlayers = new HashSet<ReferenceHub>();
 		public List<CoroutineHandle> Coroutines = new List<CoroutineHandle>();
 		public Random Gen = new Random();
 
@@ -33,7 +33,6 @@ namespace SCP008
 			Events.WaitingForPlayersEvent += EventHandlers.OnWaitingForPlayers;
 			Events.RoundEndEvent += EventHandlers.OnRoundEnd;
 			Events.PlayerHurtEvent += EventHandlers.OnPlayerHurt;
-			Events.PlayerDeathEvent += EventHandlers.OnPlayerDeath;
 			Events.UseMedicalItemEvent += EventHandlers.OnUseMedicalItem;
 			Events.RemoteAdminCommandEvent += Commands.OnRaCommand;
 		}
@@ -42,7 +41,6 @@ namespace SCP008
 		{
 			Events.WaitingForPlayersEvent -= EventHandlers.OnWaitingForPlayers;
 			Events.PlayerHurtEvent -= EventHandlers.OnPlayerHurt;
-			Events.PlayerDeathEvent -= EventHandlers.OnPlayerDeath;
 			Events.UseMedicalItemEvent -= EventHandlers.OnUseMedicalItem;
 			Events.RoundEndEvent -= EventHandlers.OnRoundEnd;
 			Events.RemoteAdminCommandEvent -= Commands.OnRaCommand;


### PR DESCRIPTION
## Why?
Many people reported RemoteKeycard letting some zombies in some doors where some O5 card holders respawned as zombies with SCP-008. Actually, they didn't tell me it was SCP-008. They didn't even tell me they had SCP-008. I just took a guess. One was even confused. I think he now believes I might be god or a hacker. Whatever...

## Changelog
- Fixed SCP-008 turning infectees into zombies, but not dropping their items (which lead to weird behaviour with anything related to RemoteKeycard and made the game look weird when they died since items popped up like a pinhata from zombies.)
- Optimized the overall flow of the plugin.
- Changed obsolete methods to comply to EXILED 1.9.0